### PR TITLE
Fix Race Condition when updating filters

### DIFF
--- a/src/components/QueueFilter/QueueFilter.jsx
+++ b/src/components/QueueFilter/QueueFilter.jsx
@@ -30,6 +30,12 @@ class QueueFilter extends Component {
       this.setQueuesDefaults();
    }
 
+   componentDidUpdate(prevProps) {
+     if (prevProps.selectedValues !== this.props.selectedValues) {
+      Flex.QueuesStats.setFilter((queue) => this.props.selectedValues.includes(queue.friendly_name));
+     }
+   }
+
     setQueuesDefaults = () => {
 
       const { selectedValues, queueValues } = this.props;	
@@ -78,8 +84,6 @@ class QueueFilter extends Component {
       //Update Worker Attributes
       Flex.Manager.getInstance().workerClient
       .setAttributes({ ...workerAttributes, queues_view_filters: this.state.selectedQueues });
-
-      Flex.QueuesStats.setFilter((queue) => this.props.selectedValues.includes(queue.friendly_name));
     }
     
   render() {


### PR DESCRIPTION
wait to update the filters on the QueueStats component until after the new worker attributes have arrived